### PR TITLE
Fix one row of checkerboard being twice as large.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -483,13 +483,13 @@ function(trace ray_origin ray_dir depth color)
         math(EXPR hit_p_x "${hit_p_x} % ${scale}")
         math(EXPR hit_p_z "${hit_p_z} % ${scale}")
 
-        # shitty hack
+        # CMake module yields negative values for negative arguments, fortunately it is easy to fix.
         if(${hit_p_x} LESS 0)
             add(${hit_p_x} ${scale} hit_p_x)
         endif()
-
-        abs(${hit_p_x} hit_p_x)
-        abs(${hit_p_z} hit_p_z)
+        if(${hit_p_z} LESS 0)
+            add(${hit_p_z} ${scale} hit_p_z)
+        endif()
 
         if((${hit_p_x} GREATER ${half}) AND (${hit_p_z} GREATER ${half}))
             set(base_col ${plane_color_1})


### PR DESCRIPTION
Hi!

In demo image one of the rows of tiles is twice as wide as the others.
This PR fixes it.

See images below: before, after.

![checkerboard with one row of tiles too wide](https://raw.githubusercontent.com/64/cmake-raytracer/master/render.png)
![checkerboard with all rows of tiles same width](https://user-images.githubusercontent.com/2843528/104135561-7f894d00-5391-11eb-95ac-4afd672457a0.png)

